### PR TITLE
Small fixes

### DIFF
--- a/src/documentation/Forms/FormViewer.stories.mdx
+++ b/src/documentation/Forms/FormViewer.stories.mdx
@@ -10,6 +10,7 @@ The form viewer expects a JSON with the following structure.
 
 ```json
 {
+  "id":"1234",
   "version": 1,
   "titleEn": "",
   "titleFr": "",
@@ -22,6 +23,8 @@ There are 2 main parts to the structure:
 
 1. Form object in the context of Form Viewer
 
+   `id`: Unique identifier for the form (`string`)
+
    `version`: Defines the static version of the form (`int`)
 
    `titleEn/Fr`: The displayed title of the form to the user (`string`)
@@ -32,7 +35,7 @@ There are 2 main parts to the structure:
 
 2. Form questions and page elements to be rendered
 
-   `id`: The unique id for the object (`int`)
+   `id`: The unique id for the object (`string`)
 
    `type`: The object question or page element type (`enum`)
 
@@ -54,13 +57,14 @@ Example:
 
 ```json
 {
+  "id": "1234",
   "version": 1,
   "titleEn": "CDS Intake Form",
   "titleFr": "SNC Formulaire d'admission",
-  "layout":[1,5,6,7]
+  "layout":["1","5","6","7"]
   "elements": [
     {
-      "id": 1,
+      "id": "1",
       "type": "textField",
       "properties": {
         "titleEn": "What is your full name?",
@@ -73,7 +77,7 @@ Example:
   		}
 		},
     {
-      "id": 5,
+      "id": "5",
       "type": "textArea",
       "properties": {
         "titleEn": "What is the problem you are facing",
@@ -86,7 +90,7 @@ Example:
       }
     },
     {
-      "id": 6,
+      "id": "6",
       "type": "textField",
       "properties": {
         "titleEn": "What is your timeline?",
@@ -99,7 +103,7 @@ Example:
       }
     },
     {
-      "id": 7,
+      "id": "7",
       "type": "textArea",
       "properties": {
         "titleEn": "How did you hear about us?",
@@ -127,25 +131,28 @@ A simple text input where the `title` property is used as the input's label.
 
 ```json
 {
-  "id": 123456789,
+  "id": "123456789",
   "type": "textField",
   "properties": {
     "titleEn": "string",
     "titleFr": "string",
     "placehoderEn": "string",
     "placeholderFr": "string",
-    "description": "string",
+    "descriptionEn": "string",
+    "descriptionFr": "string",
     "charLimit": 100,
     "required": false
   }
 }
 ```
 
+`id`: The unique id for the object (`string`)
+
 `titleEn / titleFr`: Input label (`string`)
 
 `placeholderEn / placeholderFr`: Text that will appear in the text input field as a placeholder (`string`)
 
-`description`: Secondary paragraph/text of a question or element that provides additional context beyond the label `string`)
+`descriptionEn / descriptionFr`: Secondary paragraph/text of a question or element that provides additional context beyond the label `string`)
 
 `charLimit`: The maximum number of characters that can be submitted through the input
 
@@ -159,25 +166,28 @@ A simple muli-line text input where the `title` property is used as the input's 
 
 ```json
 {
-  "id": 123456789,
+  "id": "123456789",
   "type": "textArea",
   "properties": {
     "titleEn": "string",
     "titleFr": "string",
     "placehoderEn": "string",
     "placeholderFr": "string",
-    "description": "string",
+    "descriptionEn": "string",
+    "descriptionFr": "string",
     "charLimit": 100,
     "required": false
   }
 }
 ```
 
+`id`: The unique id for the object (`string`)
+
 `titleEn / titleFr`: Input label (`string`)
 
 `placeholderEn / placeholderFr`: Text that will appear in the text input field as a placeholder (`string`)
 
-`description`: Secondary paragraph/text of a question or element that provides additional context beyond the label `string`)
+`descriptionEn / descriptionFr`: Secondary paragraph/text of a question or element that provides additional context beyond the label `string`)
 
 `charLimit`: The maximum number of characters that can be submitted through the input
 
@@ -191,7 +201,7 @@ A dropdown / select menu element that allows for a single selection.
 
 ```json
 {
-  "id":12345678,
+  "id":"12345678",
   "type":"dropdown",
   "properties":{
     "titleEn":"string",
@@ -209,9 +219,11 @@ A dropdown / select menu element that allows for a single selection.
 }
 ```
 
+`id`: The unique id for the object (`string`)
+
 `titleEn / titleFr`: Input label (`string`)
 
-`description`: Secondary paragraph/text of a question or element that provides additional context beyond the label `string`)
+`descriptionEn / descriptionFr`: Secondary paragraph/text of a question or element that provides additional context beyond the label `string`)
 
 `required`: A boolean flag identifying if the question element is a mandatory for submission (`bool`)
 
@@ -225,13 +237,13 @@ A radio button selection group that allows for a single selection
 
 ```json
 {
-  "id":123456789,
+  "id":"123456789",
   "type":"radioButton",
   "properties":{
     "titleEn":"string",
     "titleFr":"string",
-    "description":"string",
-    "description":"string",
+    "descriptionEn":"string",
+    "descriptionFr":"string",
     "required":false,
     "choices":[
       {
@@ -243,9 +255,11 @@ A radio button selection group that allows for a single selection
 }
 ```
 
+`id`: The unique id for the object (`string`)
+
 `titleEn / titleFr`: Input label (`string`)
 
-`description`: Secondary paragraph/text of a question or element that provides additional context beyond the label `string`)
+`descriptionEn / descriptionFr`: Secondary paragraph/text of a question or element that provides additional context beyond the label `string`)
 
 `required`: A boolean flag identifying if the question element is a mandatory for submission (`bool`)
 
@@ -259,13 +273,13 @@ A checkbox selection group that allows for a single or multiple selection
 
 ```json
 {
-  "id":123456789,
+  "id":"123456789",
   "type":"checkbox",
   "properties":{
     "titleEn":"string",
     "titleFr":"string",
-    "description":"string",
-    "description":"string",
+    "descriptionEn":"string",
+    "descriptionFr":"string",
     "required":false,
     "choices":[
       {
@@ -277,9 +291,11 @@ A checkbox selection group that allows for a single or multiple selection
 }
 ```
 
+`id`: The unique id for the object (`string`)
+
 `titleEn / titleFr`: Input label (`string`)
 
-`description`: Secondary paragraph/text of a question or element that provides additional context beyond the label `string`)
+`descriptionEn / descriptionFr`: Secondary paragraph/text of a question or element that provides additional context beyond the label `string`)
 
 `required`: A boolean flag identifying if the question element is a mandatory for submission (`bool`)
 


### PR DESCRIPTION
# Summary | Résumé

This PR changes the Form View documentation to align with the new ID type (string instead of number) and the proper addition of the descriptionEn and descriptionFr element property fields.
