### PR TITLE
Mod radio button type to align with form builder

### DIFF
--- a/src/documentation/Forms/FormViewer.stories.mdx
+++ b/src/documentation/Forms/FormViewer.stories.mdx
@@ -238,7 +238,7 @@ A radio button selection group that allows for a single selection
 ```json
 {
   "id":"123456789",
-  "type":"radioButton",
+  "type":"radio",
   "properties":{
     "titleEn":"string",
     "titleFr":"string",


### PR DESCRIPTION
# Summary | Résumé

This PR changes the naming type for a Radio Button from `radioButton` to `radio` to align with new form builder logic.